### PR TITLE
fix: persist annotation changes using correct Zotero API

### DIFF
--- a/src/modules/reader.ts
+++ b/src/modules/reader.ts
@@ -122,14 +122,18 @@ const handleRemoveSpaceClick = async (
       return;
     }
 
-    // Update the annotation text
-    annotation.text = processedText;
-
-    // Save the annotation
-    // Note: The exact API for saving might vary; this is based on common patterns
-    if (annotation.save) {
-      await annotation.save();
+    // Get the actual Zotero item using libraryID and key
+    const annotationItem = Zotero.Items.getByLibraryAndKey(
+      annotation.libraryID,
+      annotation.id,
+    );
+    if (!annotationItem) {
+      throw new Error("Annotation item not found");
     }
+
+    // Update and persist using the correct Zotero API
+    annotationItem.annotationText = processedText;
+    await annotationItem.saveTx();
 
     // Show success feedback
     showFeedback("message-success");


### PR DESCRIPTION
## Summary
- Fix annotation text changes not being persisted after removing spaces
- Use `Zotero.Items.getByLibraryAndKey(libraryID, key)` to retrieve the actual item
- Use `annotationText` property and `saveTx()` method to persist changes

## Root Cause
The previous code modified event parameter data (`annotation.text`) instead of the actual Zotero item. The `annotation.id` is a string key (e.g., `"BXAI4M9M"`), not a numeric ID.

## Test Plan
- [x] Build passes
- [x] Manual test: annotation text changes persist after reopening PDF

Fixes #27

Co-Authored-By: Claude